### PR TITLE
Added filter for Prepend Title, to allow users to hook and filter

### DIFF
--- a/prepare_new_version.php
+++ b/prepare_new_version.php
@@ -211,10 +211,10 @@ if( !class_exists( 'PNV' ) ) {
             // We may prepend some string to the post title
             switch( $action ) {
                 case PNV_DUPLICATE_ACTION:
-                    $destination['post_title'] = PNV_STR_DUPLICATE_PREPEND_TITLE . ' ' . $destination['post_title'];
+                    $destination['post_title'] = trim(apply_filters('pnv_duplicate_prepend_title',PNV_STR_DUPLICATE_PREPEND_TITLE).' '. $destination['post_title']);
                     break;
                 case PNV_COPY_ACTION:
-                    $destination['post_title'] = PNV_STR_COPY_PREPEND_TITLE . ' ' . $destination['post_title'];
+                    $destination['post_title'] = trim(apply_filters('pnv_copy_prepend_title',PNV_STR_COPY_PREPEND_TITLE) .' ' . $destination['post_title']);
                     break;
             }
 


### PR DESCRIPTION
When I tested this plugin, I found that creating a new version automatically prepended "[New Version]" to the title.  Also found that "Update original" does not pull that text back out of the Title.

This edit adds filters that allow plugin users to modify/remove that text from their installations via filter hooks:  pnv_duplicate_prepend_title and pnv_copy_prepend_title

The new filters can also be applied inside your 'pnv_erase_content_destination' filter to remove the text when the user clicks `<Update original>` button:

```
//*************************************************************************************
 // Apply filter provided by "Prepare New Version" plugin to remove title "Prepend" 
 //  value set with the filters above.                                             
 //*************************************************************************************
add_filter('pnv_erase_content_destination','nvly_filter_content_destination',10,3);

function nvly_filter_content_destination($destination,$source,$action){
   //if this is not a "New version" or "Copy" request...
    if ($action == PNV_ERASE_ACTION){
        // If the value prepended was for a "Duplicate" action, strip the prepended text from the title
        if (stripos($destination['post_title'],PNV_STR_DUPLICATE_PREPEND_TITLE)==0){
            $pfx = apply_filters('pnv_duplicate_prepend_title', PNV_STR_DUPLICATE_PREPEND_TITLE);
        }
        // If the value prepended was for a "Copy" action, strip the prepended text from the title
        if (stripos($destination['post_title'],PNV_STR_COPY_PREPEND_TITLE)==0){
            $pfx = apply_filters('pnv_copy_prepend_title', PNV_STR_COPY_PREPEND_TITLE);            
        }
       $destination['post_title']= trim(str_replace($pfx,'',$destination['post_title']));
    }
    return $destination;
}
```
